### PR TITLE
feat: support Flash Attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ Table of parameters
 |`model_type` | String | Model type we want to use: llm or embedding, default value is llm|
 |`model_alias`| String | Used as model_id if specified in request, mandatory in loadmodel|
 |`model`      | String | Used as model_id if specified in request, mandatory in chat/embedding request|
-|`flash-attn` | Boolean| To enable Flash Attention|
+|`flash-attn` | Boolean| To enable Flash Attention, default is false|

--- a/README.md
+++ b/README.md
@@ -145,3 +145,4 @@ Table of parameters
 |`model_type` | String | Model type we want to use: llm or embedding, default value is llm|
 |`model_alias`| String | Used as model_id if specified in request, mandatory in loadmodel|
 |`model`      | String | Used as model_id if specified in request, mandatory in chat/embedding request|
+|`flash-attn` | Boolean| To enable Flash Attention|

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -308,6 +308,10 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> jsonBody) {
         jsonBody->get("cpu_threads", std::thread::hardware_concurrency())
             .asInt();
     params.cont_batching = jsonBody->get("cont_batching", false).asBool();
+    params.flash_attn = jsonBody->get("flash-attn", false).asBool();
+    if(params.flash_attn) {
+      LOG_DEBUG << "Enabled Flash Attention";
+    }
     server_map_[model_id].caching_enabled =
         jsonBody->get("caching_enabled", false).asBool();
     server_map_[model_id].user_prompt =


### PR DESCRIPTION
Configuration: To enable Flash Attention, need to add `flash_attn`: true to model.json

Tested on windows 11 4900 cuda 12, can see an improvement on token speed
Without Flash Attention:
```
llama_new_context_with_model: flash_attn = 0
20240522 06:33:42.958000 UTC 7864 DEBUG [PrintTimings] PrintTimings: prompt eval time = 284.746ms / 80 tokens (3.559325 ms per token, 280.952146826 tokens per second) - llama_client_slot.cc:79
20240522 06:33:42.958000 UTC 7864 DEBUG [PrintTimings] PrintTimings:        eval time = 32301.621 ms / 297 runs   (108.759666667 ms per token, 9.19458500241 tokens per second)
 - llama_client_slot.cc:86
```

With Flash Attention:
```
llama_new_context_with_model: flash_attn = 1
20240522 06:31:41.109000 UTC 4872 DEBUG [PrintTimings] PrintTimings: prompt eval time = 632.817ms / 84 tokens (7.53353571429 ms per token, 132.739796813 tokens per second) - llama_client_slot.cc:79
20240522 06:31:41.109000 UTC 4872 DEBUG [PrintTimings] PrintTimings:        eval time = 47647.218 ms / 455 runs   (104.71916044 ms per token, 9.54935081414 tokens per second)
 - llama_client_slot.cc:86
```