### PR TITLE
feat: add more info on getting models

### DIFF
--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -1,5 +1,6 @@
 #include "llama_engine.h"
 
+#include <chrono>
 #include "json/writer.h"
 #include "llama_utils.h"
 #include "trantor/utils/Logger.h"
@@ -259,6 +260,10 @@ void LlamaEngine::GetModels(
     if (s.ctx.model_loaded_external) {
       Json::Value val;
       val["id"] = m;
+      val["engine"] = "cortex.llamacpp";
+      val["start_time"] = s.start_time;
+      val["vram"] = "-";
+      val["ram"] = "-";
       val["object"] = "model";
       model_array.append(val);
     }
@@ -397,6 +402,9 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> jsonBody) {
 
   server_map_[model_id].q = std::make_unique<trantor::ConcurrentTaskQueue>(
       params.n_parallel, model_id);
+  server_map_[model_id].start_time =
+      std::chrono::system_clock::now().time_since_epoch() /
+      std::chrono::milliseconds(1);
 
   // For model like nomic-embed-text-v1.5.f16.gguf, etc, we don't need to warm up model.
   // So we use this variable to differentiate with other models

--- a/src/llama_engine.h
+++ b/src/llama_engine.h
@@ -53,6 +53,9 @@ class LlamaEngine : public EngineI {
     int repeat_last_n;
     bool caching_enabled;
     std::string grammar_file_content;
+    uint64_t start_time;
+    uint32_t vram;
+    uint32_t dram;
   };
 
   // key: model_id, value: ServerInfo


### PR DESCRIPTION
Example:
```
{
    "data": [
        {
            "id": "nomic-embed-text-v1.5.f16",
	    "engine": "cortex.llamacpp",
	    "start_time": 1716966123266, // Epoch time in miliseconds
	    "vram": "123", // MiB
	    "ram": "-", // For unknown 
            "object": "model"
        }
    ],
    "object": "list"
}
```
We don't have VRAM and RAM yet. Will add it later.