### PR TITLE
chore: changes windows CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,25 +109,25 @@ jobs:
             vulkan: false
           - os: "windows"
             name: "amd64-avx2"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
           - os: "windows"
             name: "amd64-avx"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
           - os: "windows"
             name: "amd64-avx512"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             vulkan: false
           - os: "windows"
             name: "amd64-vulkan"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             vulkan: true

--- a/.github/workflows/quality-gate-submodule.yml
+++ b/.github/workflows/quality-gate-submodule.yml
@@ -68,13 +68,13 @@ jobs:
             vulkan: false
           - os: "windows"
             name: "amd64-avx2"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
           - os: "windows"
             name: "amd64-avx"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
@@ -86,7 +86,7 @@ jobs:
             vulkan: false
           - os: "windows"
             name: "amd64-vulkan"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             vulkan: true

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -68,25 +68,25 @@ jobs:
             vulkan: false
           - os: "windows"
             name: "amd64-avx2"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
           - os: "windows"
             name: "amd64-avx"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             vulkan: false
           - os: "windows"
             name: "amd64-avx512"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             vulkan: false
           - os: "windows"
             name: "amd64-vulkan"
-            runs-on: "windows-latest"
+            runs-on: "windows-2019"
             cmake-flags: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             vulkan: true


### PR DESCRIPTION
windows-latest after https://github.com/actions/runner-images/releases/tag/win22%2F20240603.1 has a bug that makes http server crashes.  
Use windows-2019 as runners for now.