### PR TITLE
Update llama.cpp submodule to latest release b3600

### DIFF
--- a/src/llama_server_context.cc
+++ b/src/llama_server_context.cc
@@ -209,7 +209,7 @@ bool LlamaServerContext::LoadModel(const gpt_params& params_) {
   }
   n_ctx = llama_n_ctx(ctx);
 
-  add_bos_token = llama_should_add_bos_token(model);
+  add_bos_token = llama_add_bos_token(model);
 
   return true;
 }


### PR DESCRIPTION
This PR updates the llama.cpp submodule to the latest release: b3600.