### PR TITLE
chore: use macos-12 instead of macos-13 for mac intel runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
             sccache-conf-path: "/tmp/sccache.conf"
           - os: "mac"
             name: "amd64"
-            runs-on: "macos-13"
+            runs-on: "macos-12"
             cmake-flags: "-DCORTEXLLAMA_VERSION=${{needs.create-draft-release.outputs.version}} -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF"
             run-e2e: true
             vulkan: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -167,7 +167,7 @@ jobs:
             sccache-conf-path: "/tmp/sccache.conf"
           - os: "mac"
             name: "amd64"
-            runs-on: "macos-13"
+            runs-on: "macos-12"
             cmake-flags: "-DCORTEXLLAMA_VERSION=${{needs.create-draft-release.outputs.version}} -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF"
             run-e2e: true
             vulkan: false

--- a/.github/workflows/template-e2e-weekend-test.yml
+++ b/.github/workflows/template-e2e-weekend-test.yml
@@ -50,7 +50,7 @@ jobs:
 
           - os: "mac"
             name: "amd64"
-            runs-on: "macos-13"
+            runs-on: "macos-12"
             cmake-flags: "-DCORTEXLLAMA_VERSION=${{github.event.pull_request.head.sha}} -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF"
             run-e2e: true
             vulkan: false

--- a/.github/workflows/template-quality-gate-pr.yml
+++ b/.github/workflows/template-quality-gate-pr.yml
@@ -134,7 +134,7 @@ jobs:
             sccache-conf-path: "/tmp/sccache.conf"
           - os: "mac"
             name: "amd64"
-            runs-on: "macos-13"
+            runs-on: "macos-12"
             cmake-flags: "-DCORTEXLLAMA_VERSION=${{github.event.pull_request.head.sha}} -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF"
             run-e2e: true
             vulkan: false

--- a/.github/workflows/template-quality-gate-submodule.yml
+++ b/.github/workflows/template-quality-gate-submodule.yml
@@ -134,7 +134,7 @@ jobs:
             sccache-conf-path: "/tmp/sccache.conf"
           - os: "mac"
             name: "amd64"
-            runs-on: "macos-13"
+            runs-on: "macos-12"
             cmake-flags: "-DCORTEXLLAMA_VERSION=${{github.event.pull_request.head.sha}} -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF"
             run-e2e: true
             vulkan: false


### PR DESCRIPTION
We are using macos-13 for mac intel runner (not sure why)
Use macos-12 for now to support more mac OS version.