### PR TITLE
Feat/support logit bias

### DIFF
--- a/src/chat_completion_request.h
+++ b/src/chat_completion_request.h
@@ -2,7 +2,6 @@
 #include <json.hpp>
 #include "json/value.h"
 #include "sampling.h"
-#include "trantor/utils/Logger.h"
 namespace llama::inferences {
 
 nlohmann::json ConvertJsonCppToNlohmann(const Json::Value& input) {

--- a/src/chat_completion_request.h
+++ b/src/chat_completion_request.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "json/value.h"
 #include "sampling.h"
+#include "llama.h"
 
 namespace llama::inferences {
 struct ChatCompletionRequest {
@@ -31,6 +32,7 @@ struct ChatCompletionRequest {
   int n_probs = 0;
   int min_keep = 0;
   std::string grammar;
+  std::vector<llama_logit_bias> logit_bias;
 };
 
 inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
@@ -66,6 +68,7 @@ inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
     completion.n_probs = (*jsonBody).get("n_probs", 0).asInt();
     completion.min_keep = (*jsonBody).get("min_keep", 0).asInt();
     completion.grammar = (*jsonBody).get("grammar", "").asString();
+    completion.logit_bias = (*jsonBody)["logit_bias"];
   }
   return completion;
 }

--- a/src/chat_completion_request.h
+++ b/src/chat_completion_request.h
@@ -2,7 +2,7 @@
 #include <json.hpp>
 #include "json/value.h"
 #include "sampling.h"
-
+#include "trantor/utils/Logger.h"
 namespace llama::inferences {
 
 nlohmann::json ConvertJsonCppToNlohmann(const Json::Value& input) {
@@ -112,10 +112,10 @@ inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
     completion.n_probs = (*jsonBody).get("n_probs", 0).asInt();
     completion.min_keep = (*jsonBody).get("min_keep", 0).asInt();
     completion.grammar = (*jsonBody).get("grammar", "").asString();
-    const Json::Value& inputLogitBias = (*jsonBody)["logit_bias"];
-    if (!inputLogitBias.isNull()) {
+    const Json::Value& input_logit_bias = (*jsonBody)["logit_bias"];
+    if (!input_logit_bias.isNull()) {
       completion.logit_bias =
-          ChatCompletionRequest::ConvertLogitBiasToArray(inputLogitBias);
+          ChatCompletionRequest::ConvertLogitBiasToArray(input_logit_bias);
     }
   }
   return completion;

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -635,6 +635,7 @@ void LlamaEngine::HandleInferenceImpl(
   data["n_probs"] = completion.n_probs;
   data["min_keep"] = completion.min_keep;
   data["grammar"] = completion.grammar;
+  data["logit_bias"] = completion.logit_bias;
   int n_probs = completion.n_probs;
   const Json::Value& messages = completion.messages;
 

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -345,16 +345,16 @@ void LlamaEngine::GetModels(
   Json::Value model_array(Json::arrayValue);
   for (const auto& [m, s] : server_map_) {
     if (s.ctx.model_loaded_external) {
-      // uint64_t vram = llama_get_other_buffer(s.ctx.model);
-      // uint64_t ram = llama_get_cpu_buffer(s.ctx.model);
+      uint64_t vram = llama_get_other_buffer(s.ctx.model);
+      uint64_t ram = llama_get_cpu_buffer(s.ctx.model);
 
       Json::Value val;
       val["id"] = m;
       val["engine"] = "cortex.llamacpp";
       val["start_time"] = s.start_time;
       val["model_size"] = llama_model_size(s.ctx.model);
-      // val["vram"] = vram;
-      // val["ram"] = ram;
+      val["vram"] = vram;
+      val["ram"] = ram;
       val["object"] = "model";
       model_array.append(val);
     }

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -345,16 +345,16 @@ void LlamaEngine::GetModels(
   Json::Value model_array(Json::arrayValue);
   for (const auto& [m, s] : server_map_) {
     if (s.ctx.model_loaded_external) {
-      uint64_t vram = llama_get_other_buffer(s.ctx.model);
-      uint64_t ram = llama_get_cpu_buffer(s.ctx.model);
+      // uint64_t vram = llama_get_other_buffer(s.ctx.model);
+      // uint64_t ram = llama_get_cpu_buffer(s.ctx.model);
 
       Json::Value val;
       val["id"] = m;
       val["engine"] = "cortex.llamacpp";
       val["start_time"] = s.start_time;
       val["model_size"] = llama_model_size(s.ctx.model);
-      val["vram"] = vram;
-      val["ram"] = ram;
+      // val["vram"] = vram;
+      // val["ram"] = ram;
       val["object"] = "model";
       model_array.append(val);
     }
@@ -635,7 +635,11 @@ void LlamaEngine::HandleInferenceImpl(
   data["n_probs"] = completion.n_probs;
   data["min_keep"] = completion.min_keep;
   data["grammar"] = completion.grammar;
-  data["logit_bias"] = completion.logit_bias;
+  json arr = json::array();
+  for (const auto& elem : completion.logit_bias) {
+    arr.push_back(llama::inferences::ConvertJsonCppToNlohmann(elem));
+  }
+  data["logit_bias"] = std::move(arr);
   int n_probs = completion.n_probs;
   const Json::Value& messages = completion.messages;
 


### PR DESCRIPTION
Fix #263 

request example:
```
  curl http://localhost:3928/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "engine":"cortex.llamacpp",
    "logit_bias":{"12345":1},
    "model": "meta-llama3.1-8b-instruct",
    "n_probs":1,
    "stream":false,
    "top_k":20,
    "messages": [
      {
        "role": "user",
        "content": "Who won the world series in 2020?"
      },
    ]
  }'
```

Accepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100 (source: https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias)
