### PR TITLE
support OpenAI compatible log probs

### DIFF
--- a/src/chat_completion_request.h
+++ b/src/chat_completion_request.h
@@ -4,6 +4,33 @@
 #include "sampling.h"
 namespace llama::inferences {
 
+Json::Value ConvertNlohmannToJsonCpp(const nlohmann::json& input) {
+    if (input.is_null()) {
+        return Json::Value(Json::nullValue);
+    } else if (input.is_boolean()) {
+        return Json::Value(input.get<bool>());
+    } else if (input.is_number_integer()) {
+        return Json::Value(input.get<int>());
+    } else if (input.is_number_float()) {
+        return Json::Value(input.get<double>());
+    } else if (input.is_string()) {
+        return Json::Value(input.get<std::string>());
+    } else if (input.is_array()) {
+        Json::Value arr(Json::arrayValue);
+        for (const auto& elem : input) {
+            arr.append(ConvertNlohmannToJsonCpp(elem));
+        }
+        return arr;
+    } else if (input.is_object()) {
+        Json::Value obj(Json::objectValue);
+        for (auto it = input.begin(); it != input.end(); ++it) {
+            obj[it.key()] = ConvertNlohmannToJsonCpp(it.value());
+        }
+        return obj;
+    }
+    return Json::Value(Json::nullValue);
+}
+
 nlohmann::json ConvertJsonCppToNlohmann(const Json::Value& input) {
   if (input.isNull()) {
     return nullptr;
@@ -54,6 +81,7 @@ struct ChatCompletionRequest {
   float mirostat_eta = 0.1f;
   bool penalize_nl = false;
   bool ignore_eos = false;
+  bool logprobs = false;
   int n_probs = 0;
   int min_keep = 0;
   bool include_usage = false;
@@ -80,10 +108,11 @@ inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
   common_sampler_params default_params;
   if (jsonBody) {
     completion.stream = (*jsonBody).get("stream", false).asBool();
-    if(completion.stream) {
+    if (completion.stream) {
       auto& stream_options = (*jsonBody)["stream_options"];
-      if(!stream_options.isNull()) {
-        completion.include_usage = stream_options.get("include_usage", false).asBool();
+      if (!stream_options.isNull()) {
+        completion.include_usage =
+            stream_options.get("include_usage", false).asBool();
       }
     }
     completion.max_tokens = (*jsonBody).get("max_tokens", 500).asInt();
@@ -113,7 +142,10 @@ inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
     completion.mirostat_eta = (*jsonBody).get("mirostat_eta", 0.1f).asFloat();
     completion.penalize_nl = (*jsonBody).get("penalize_nl", true).asBool();
     completion.ignore_eos = (*jsonBody).get("ignore_eos", false).asBool();
-    completion.n_probs = (*jsonBody).get("n_probs", 0).asInt();
+    completion.logprobs = (*jsonBody).get("logprobs", false).asBool();
+    if (completion.logprobs) {
+      completion.n_probs = (*jsonBody).get("top_logprobs", 0).asInt();
+    }
     completion.min_keep = (*jsonBody).get("min_keep", 0).asInt();
     completion.grammar = (*jsonBody).get("grammar", "").asString();
     const Json::Value& input_logit_bias = (*jsonBody)["logit_bias"];

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -90,8 +90,7 @@ Json::Value TransformLogProbs(const json& logprobs) {
     }
 
     // Get UTF-8 bytes for the token
-    std::vector<int> bytes =
-        getUTF8Bytes(token_group["content"].get<std::string>());
+    auto bytes = getUTF8Bytes(token_group["content"].get<std::string>());
     Json::Value bytes_array(Json::arrayValue);
     for (int byte : bytes) {
       bytes_array.append(byte);
@@ -106,8 +105,7 @@ Json::Value TransformLogProbs(const json& logprobs) {
       logprob_item["logprob"] = prob_item["prob"].get<double>();
 
       // Get UTF-8 bytes for this alternative token
-      std::vector<int> alt_bytes =
-          getUTF8Bytes(prob_item["tok_str"].get<std::string>());
+      auto alt_bytes = getUTF8Bytes(prob_item["tok_str"].get<std::string>());
       Json::Value alt_bytes_array(Json::arrayValue);
       for (int byte : alt_bytes) {
         alt_bytes_array.append(byte);
@@ -910,7 +908,7 @@ void LlamaEngine::HandleInferenceImpl(
     int n = completion.n;
     auto state = CreateInferenceState(si.ctx);
 
-    si.q->runTaskInQueue([this,n, n_probs, request_id, state,
+    si.q->runTaskInQueue([this, n, n_probs, request_id, state,
                           cb = std::move(callback), d = std::move(data)]() {
       Json::Value respData;
       std::vector<int> task_ids;
@@ -939,16 +937,18 @@ void LlamaEngine::HandleInferenceImpl(
             std::string to_send = result.result_json["content"];
             llama_utils::ltrim(to_send);
             if (n_probs > 0) {
-                logprobs = result.result_json["completion_probabilities"];
+              logprobs = result.result_json["completion_probabilities"];
             }
             if (respData.empty()) {
               respData = CreateFullReturnJson(
                   llama_utils::generate_random_string(20), "_", to_send, "_",
-                  prompt_tokens, predicted_tokens, Json::Value("stop"), logprobs);
+                  prompt_tokens, predicted_tokens, Json::Value("stop"),
+                  logprobs);
             } else {
               auto choice = CreateFullReturnJson(
                   llama_utils::generate_random_string(20), "_", to_send, "_",
-                  prompt_tokens, predicted_tokens, Json::Value("stop"), logprobs)["choices"][0];
+                  prompt_tokens, predicted_tokens, Json::Value("stop"),
+                  logprobs)["choices"][0];
               choice["index"] = index;
               respData["choices"].append(choice);
             }

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -932,6 +932,7 @@ void LlamaEngine::HandleInferenceImpl(
         int index = 0;
         for (auto& result : results) {
           if (!result.error && result.stop) {
+            json logprobs;
             prompt_tokens += result.result_json["tokens_evaluated"].get<int>();
             predicted_tokens +=
                 result.result_json["tokens_predicted"].get<int>();

--- a/src/llama_server_context.cc
+++ b/src/llama_server_context.cc
@@ -781,6 +781,8 @@ bool LlamaServerContext::ProcessToken(CompletionTokenOutput& result,
     slot.AddTokenString(result);
     if (slot.params.stream) {
       SendPartialResponse(slot, result);
+    } else {
+      slot.sent_token_probs_index++;
     }
   }
 
@@ -998,7 +1000,7 @@ void LlamaServerContext::SendFinalResponse(LlamaClientSlot& slot) {
           common_tokenize(ctx, slot.stopping_word, false);
       probs = std::vector<CompletionTokenOutput>(
           slot.generated_token_probs.begin(),
-          slot.generated_token_probs.end() - stop_word_toks.size());
+          slot.generated_token_probs.end() - 1);
     } else {
       probs = std::vector<CompletionTokenOutput>(
           slot.generated_token_probs.begin(),


### PR DESCRIPTION
Fix #262 

Can test this feature by use openai lib
```
from openai import OpenAI
ENDPOINT = "http://localhost:3928/v1"
MODEL = "meta-llama3.1-8b-instruct"

client = OpenAI(
    # This is the default and can be omitted
    base_url=ENDPOINT,
    api_key="not-needed"
)
completion_payload = {
    "messages": [
        {"role": "user", "content": "Who won the world series in 2020?"}
    ]
}
response = client.chat.completions.create(
    top_p=0.9,
    temperature=0.6,
    model=MODEL,
    messages= completion_payload["messages"],
    top_logprobs=2,
    stream=False,
    logprobs=True
)
print(response)
```