### PR TITLE
Update llama.cpp submodule to latest release b4079

### DIFF
--- a/patches/0001-Add-API-query-buffer-size.patch
+++ b/patches/0001-Add-API-query-buffer-size.patch
@@ -32,9 +32,9 @@ index c466cd88..15f3102c 100644
  
 +const size_t llama_get_cpu_buffer(const struct llama_model * model) {
 +    size_t buffer{0};
-+    for (const auto buf : model->bufs) {
-+        if (strcmp(ggml_backend_buffer_name(buf), "CPU") == 0) {
-+            buffer += ggml_backend_buffer_get_size(buf);
++    for (const auto& buf : model->bufs) {
++        if (strcmp(ggml_backend_buffer_name(buf.get()), "CPU") == 0) {
++            buffer += ggml_backend_buffer_get_size(buf.get());
 +        }
 +    }
 +    return buffer;
@@ -42,9 +42,9 @@ index c466cd88..15f3102c 100644
 +
 +const size_t llama_get_other_buffer(const struct llama_model * model) {
 +    size_t buffer{0};
-+    for (const auto buf : model->bufs) {
-+        if (strcmp(ggml_backend_buffer_name(buf), "CPU") != 0) {
-+            buffer += ggml_backend_buffer_get_size(buf);
++    for (const auto& buf : model->bufs) {
++        if (strcmp(ggml_backend_buffer_name(buf.get()), "CPU") != 0) {
++            buffer += ggml_backend_buffer_get_size(buf.get());
 +        }
 +    }
 +    return buffer;

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -476,8 +476,8 @@ void LlamaEngine::SetFileLogger(int max_log_lines,
         }
       },
       nullptr);
-  freopen(log_path.c_str(), "w", stderr);
-  freopen(log_path.c_str(), "w", stdout);
+  freopen(log_path.c_str(), "a", stderr);
+  freopen(log_path.c_str(), "a", stdout);
 }
 
 bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> json_body) {


### PR DESCRIPTION
This PR updates the llama.cpp submodule to the latest release: b4079.