### PR TITLE
Update llama.cpp submodule to latest release b4201

### DIFF
--- a/src/chat_completion_request.h
+++ b/src/chat_completion_request.h
@@ -106,7 +106,7 @@ struct ChatCompletionRequest {
 
 inline ChatCompletionRequest fromJson(std::shared_ptr<Json::Value> jsonBody) {
   ChatCompletionRequest completion;
-  common_sampler_params default_params;
+  common_params_sampling default_params;
   if (jsonBody) {
     completion.stream = (*jsonBody).get("stream", false).asBool();
     if (completion.stream) {

--- a/src/llama_client_slot.h
+++ b/src/llama_client_slot.h
@@ -133,7 +133,7 @@ struct LlamaClientSlot {
   std::string stopping_word;
 
   // sampling
-  struct common_sampler_params sparams;
+  struct common_params_sampling sparams;
   struct common_sampler* smpl = nullptr;
 
   // multimodal

--- a/src/llama_server_context.cc
+++ b/src/llama_server_context.cc
@@ -445,7 +445,7 @@ LlamaClientSlot* LlamaServerContext::GetSlot(int id) {
 bool LlamaServerContext::LaunchSlotWithData(LlamaClientSlot*& slot, json data) {
   SlotParams default_params;
   // Sampling parameter defaults are loaded from the global server context (but individual requests can still override them)
-  auto default_sparams = params.sparams;
+  auto default_sparams = params.sampling;
 
   if (data.count("__oaicompat") != 0) {
     slot->oaicompat = true;


### PR DESCRIPTION
This PR updates the llama.cpp submodule to the latest release: b4201.