### PR TITLE
fix: add ctx_shift parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,4 @@ Table of parameters
 |`flash_attn` | Boolean| To enable Flash Attention, default is true|
 |`cache_type` | String| KV cache type: f16, q8_0, q4_0, default is f16|
 |`use_mmap` | Boolean| To enable mmap, default is true|
+|`ctx_shift` | Boolean| To enable context shift, default is true|

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -270,24 +270,18 @@ std::string CreateReturnJson(const std::string& id, const std::string& model,
 }
 
 const std::vector<ggml_type> kv_cache_types = {
-    GGML_TYPE_F32,
-    GGML_TYPE_F16,
-    GGML_TYPE_BF16,
-    GGML_TYPE_Q8_0,
-    GGML_TYPE_Q4_0,
-    GGML_TYPE_Q4_1,
-    GGML_TYPE_IQ4_NL,
-    GGML_TYPE_Q5_0,
-    GGML_TYPE_Q5_1,
+    GGML_TYPE_F32,    GGML_TYPE_F16,  GGML_TYPE_BF16,
+    GGML_TYPE_Q8_0,   GGML_TYPE_Q4_0, GGML_TYPE_Q4_1,
+    GGML_TYPE_IQ4_NL, GGML_TYPE_Q5_0, GGML_TYPE_Q5_1,
 };
 
-ggml_type kv_cache_type_from_str(const std::string & s) {
-    for (const auto & type : kv_cache_types) {
-        if (ggml_type_name(type) == s) {
-            return type;
-        }
+ggml_type kv_cache_type_from_str(const std::string& s) {
+  for (const auto& type : kv_cache_types) {
+    if (ggml_type_name(type) == s) {
+      return type;
     }
-    throw std::runtime_error("Unsupported cache type: " + s);
+  }
+  throw std::runtime_error("Unsupported cache type: " + s);
 }
 
 }  // namespace
@@ -611,6 +605,7 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> json_body) {
       }
     }
 
+    params.ctx_shift = json_body->get("ctx_shift", true).asBool();
     params.n_gpu_layers =
         json_body->get("ngl", 300)
             .asInt();  // change from 100 -> 300 since llama 3.1 has 292 gpu layers


### PR DESCRIPTION
This pull request includes changes to the `src/llama_engine.cc` file to improve code readability and add new parameters to the `LoadModelImpl` function. The most important changes are:

Code readability improvements:

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bL273-R275): Reformatted the `kv_cache_types` vector to improve readability by aligning the elements in columns.

Functionality enhancements:

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bR608): Added a new parameter `ctx_shift` to the `LoadModelImpl` function, with a default value of `true`. This parameter is extracted from the `json_body`.

Issue: https://github.com/janhq/cortex.cpp/issues/1843