### PR TITLE
chore: down log level

### DIFF
--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -287,7 +287,7 @@ ggml_type kv_cache_type_from_str(const std::string& s) {
 }  // namespace
 
 void LlamaEngine::Load(EngineLoadOption opts) {
-  LOG_INFO << "Loading engine..";
+  LOG_DEBUG << "Loading engine..";
 
   LOG_DEBUG << "Is custom engine path: " << opts.is_custom_engine_path;
   LOG_DEBUG << "Engine path: " << opts.engine_path.string();


### PR DESCRIPTION
This pull request includes a change to the logging level in the `LlamaEngine::Load` method to provide more detailed debugging information.

Logging level change:

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bL290-R290): Changed the logging level from `LOG_INFO` to `LOG_DEBUG` in the `LlamaEngine::Load` method to provide more detailed information during the engine loading process.