### PR TITLE
fix: temporary disable warm up for deepseek-r1

### DIFF
--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -66,6 +66,13 @@ bool AreAllElementsInt32(const Json::Value& arr) {
   return true;
 }
 
+std::string ToLower(const std::string& s) {
+  std::string data = s;
+  std::transform(data.begin(), data.end(), data.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return data;
+}
+
 struct InferenceState {
   int task_id;
   LlamaServerContext& llama;
@@ -726,7 +733,7 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> json_body) {
   // For model like nomic-embed-text-v1.5.f16.gguf, etc, we don't need to warm up model.
   // So we use this variable to differentiate with other models
   if (server_map_[model_id].ctx.model_type == ModelType::kLlm) {
-    if (model_id.find("deepseek-r1") == std::string::npos) {
+    if (ToLower(model_id).find("deepseek-r1") == std::string::npos) {
       WarmUpModel(model_id);
     }
   }
@@ -849,7 +856,8 @@ void LlamaEngine::HandleInferenceImpl(
         if (auto content = get_message(message["content"]); !content.empty()) {
           formatted_output += role + content;
           if (input_role == "assistant" &&
-              (completion.model_id.find("deepseek-r1") != std::string::npos)) {
+              (ToLower(completion.model_id).find("deepseek-r1") !=
+               std::string::npos)) {
             formatted_output += "<｜end▁of▁sentence｜>";
           }
         }

--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -726,7 +726,9 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> json_body) {
   // For model like nomic-embed-text-v1.5.f16.gguf, etc, we don't need to warm up model.
   // So we use this variable to differentiate with other models
   if (server_map_[model_id].ctx.model_type == ModelType::kLlm) {
-    WarmUpModel(model_id);
+    if (model_id.find("deepseek-r1") == std::string::npos) {
+      WarmUpModel(model_id);
+    }
   }
   return true;
 }
@@ -846,6 +848,10 @@ void LlamaEngine::HandleInferenceImpl(
 
         if (auto content = get_message(message["content"]); !content.empty()) {
           formatted_output += role + content;
+          if (input_role == "assistant" &&
+              (completion.model_id.find("deepseek-r1") != std::string::npos)) {
+            formatted_output += "<｜end▁of▁sentence｜>";
+          }
         }
       }
       formatted_output += si.ai_prompt;


### PR DESCRIPTION
This pull request includes changes to the `src/llama_engine.cc` file to handle specific model types and improve the inference process. The most important changes are:

Model handling improvements:

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bR729-R732): Added a condition to skip the warm-up process for models with IDs containing "deepseek-r1".

Inference process enhancements:

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bR851-R854): Modified the `HandleInferenceImpl` method to append a specific end-of-sentence marker for models with IDs containing "deepseek-r1" when the input role is "assistant".