### PR TITLE
feat: add runner cuda 12.4 for windows and ubuntu

### DIFF
--- a/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
+++ b/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
@@ -1,0 +1,94 @@
+# Use NVIDIA CUDA 12.4.0 development image with Ubuntu 22.04 as the base
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04
+
+# Docker and Docker Compose arguments
+
+# Use 1001 and 121 for compatibility with GitHub-hosted runners
+ARG RUNNER_UID=1000
+ARG DOCKER_GID=1001
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary packages
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    dnsutils \
+    ftp \
+    git \
+    uuid-dev \
+    iproute2 \
+    iputils-ping \
+    jq \
+    libunwind8 \
+    locales \
+    netcat \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
+    sudo \
+    telnet \
+    time \
+    tzdata \
+    unzip \
+    upx \
+    wget \
+    lsb-release \
+    openssl \
+    libssl-dev \
+    manpages-dev \
+    zip \
+    zstd \
+    pkg-config \
+    ccache \
+    gcc \
+    g++ \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Kitware's APT repository for CMake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y cmake
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
+
+ARG RUNNER_VERSION=2.319.1
+
+RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
+&& groupadd docker --gid $DOCKER_GID \
+&& usermod -aG sudo runner \
+&& usermod -aG docker runner \
+&& echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+&& echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+
+ENV HOME=/home/runner
+
+# cd into the user directory, download and unzip the github actions runner
+RUN cd /home/runner && mkdir actions-runner && cd actions-runner \
+    && curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+
+RUN chown -R runner:runner /home/runner && /home/runner/actions-runner/bin/installdependencies.sh
+
+ADD ./start.sh /home/runner/start.sh
+
+RUN chmod +x /home/runner/start.sh
+
+# Update the CUDA compatibility libraries path for 12.4
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.4/compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+ENTRYPOINT ["/bin/bash", "/home/runner/start.sh"]
+
+USER runner

--- a/.github/runners/actions-runner-windows-cuda-12-4.dockerfile
+++ b/.github/runners/actions-runner-windows-cuda-12-4.dockerfile
@@ -1,0 +1,52 @@
+FROM mcr.microsoft.com/windows/server:ltsc2022
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';$ProgressPreference='silentlyContinue';"]
+
+ARG RUNNER_VERSION=2.311.0
+
+RUN Invoke-WebRequest \
+      -Uri 'https://aka.ms/install-powershell.ps1' \
+      -OutFile install-powershell.ps1; \
+    powershell -ExecutionPolicy Unrestricted -File ./install-powershell.ps1 -AddToPath
+
+RUN Invoke-WebRequest \
+      -Uri https://github.com/actions/runner/releases/download/v$env:RUNNER_VERSION/actions-runner-win-x64-$env:RUNNER_VERSION.zip \
+      -OutFile runner.zip; \
+    Expand-Archive -Path C:/runner.zip -DestinationPath C:/actions-runner; \
+    Remove-Item -Path C:\runner.zip; \
+    setx /M PATH $(${Env:PATH} + \";${Env:ProgramFiles}\Git\bin\")
+
+# Install Chocolatey
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Upgrade Git
+RUN choco install git -y; \
+    git --version
+
+# Install 7zip
+RUN choco install 7zip -y; \
+    7z --help
+
+# Install cmake and add to path
+RUN choco install cmake.install -y --installargs '"ADD_CMAKE_TO_PATH=System"'
+
+RUN cmake --version
+
+# Install MSBuild and add to path
+RUN choco install visualstudio2022buildtools -y --package-parameters '"--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.14.29.CLI.Support --add Microsoft.VisualStudio.Component.VC.14.29.CMake.Project --add Microsoft.VisualStudio.Component.VC.14.29.MFC --add Microsoft.VisualStudio.Component.VC.14.29.MSBuild --add Microsoft.VisualStudio.Component.VC.14.29.VCRedist.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.VSTools.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.VC.ASAN --add Microsoft.VisualStudio.Component.VC.14.29.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.14.29.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.14.29.VC.FxCop --add Microsoft.VisualStudio.Component.VC.14.29.VC.MFC --add Microsoft.VisualStudio.Component.VC.14.29.VC.MSBuild --add Microsoft.VisualStudio.Component.VC.14.29.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.14.29.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.VC.VCUnitTest --add Microsoft.VisualStudio.Component.VC.14.29.VC.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.VC.x86.x64.Latest --add Microsoft.VisualStudio.Component.VC.14.29.VisualStudioCppSDK --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win10 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.LegacyBuildTools --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.DiagnosticTools --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Llvm.Cmake --add Microsoft.VisualStudio.Component.VC.Llvm.Llvm --add Microsoft.VisualStudio.Component.VC.Llvm.Toolset --add Microsoft.VisualStudio.Component.VC.MFC --add Microsoft.VisualStudio.Component.VC.MSBuild --add Microsoft.VisualStudio"'
+
+RUN choco install gzip -y;
+
+# Install cuda toolkit 12.4.1
+RUN choco install cuda --version=12.4.1.551 -y
+
+# Copy integrated tools to MSBuild
+RUN Copy-Item -Path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\extras\visual_studio_integration\MSBuildExtensions\*' -Destination 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\BuildCustomizations'
+RUN Copy-Item -Path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\extras\visual_studio_integration\MSBuildExtensions\*' -Destination 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations'
+
+ADD runner.ps1 C:/runner.ps1
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=amd64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+CMD ["powershell.exe", "-ExecutionPolicy", "Unrestricted", "-File", ".\\runner.ps1"]


### PR DESCRIPTION
This pull request introduces Dockerfiles for setting up GitHub Actions runners with CUDA 12.4 on both Ubuntu and Windows platforms. The most important changes include specifying base images, installing necessary packages, and configuring environment settings for both operating systems.

### Ubuntu Runner Setup:
* Added a Dockerfile to use NVIDIA CUDA 12.4.0 development image with Ubuntu 22.04 as the base.
* Installed essential packages and tools, including `git`, `cmake`, and `git-lfs`.
* Configured user and group settings for compatibility with GitHub-hosted runners.
* Set up the GitHub Actions runner and its dependencies.

### Windows Runner Setup:
* Added a Dockerfile to use Windows Server LTSC 2022 as the base image.
* Installed necessary tools using Chocolatey, including `git`, `cmake`, `7zip`, and CUDA toolkit 12.4.1.
* Configured PowerShell for script execution and set up the GitHub Actions runner.